### PR TITLE
coru_platform [ARM]: fix for Wincompatible-pointer-types warning

### DIFF
--- a/coru_platform.c
+++ b/coru_platform.c
@@ -156,7 +156,7 @@ int coru_plat_init(void **psp, uintptr_t **pcanary,
 
     // setup stack pointer and canary
     *psp = &sp[-9];
-    *pcanary = &sp[-size/sizeof(uint32_t)];
+    *pcanary = (uintptr_t *)&sp[-size/sizeof(uint32_t)];
     return 0;
 }
 


### PR DESCRIPTION
Hi geky,

I have found one of your other nice little projects :)

I propose a small fix in this pull request, since I noticed that my ARM GCC compiler was generating the following warning:
```
../../../libs/coru/coru_platform.c: In function 'coru_plat_init':                                                                                                                                                                                                               
../../../libs/coru/coru_platform.c:159:14: warning: assignment to 'uintptr_t *' {aka 'unsigned int *'} from incompatible pointer type 'uint32_t *' {aka 'long unsigned int *'} [-Wincompatible-pointer-types]                                                                   
  159 |     *pcanary = &sp[-size/sizeof(uint32_t)];                                                                                                                                                                                                                             
      |              ^                                           
```

The warning should be harmless, since it's only converting between pointers to a long unsigned integer on the one hand and an unsigned integer on the other hand, but I figured you might want to have this warning fixed anyway.
